### PR TITLE
Avoid re-sync blocks on process failure

### DIFF
--- a/app/services/tezos/governance_sync_service.rb
+++ b/app/services/tezos/governance_sync_service.rb
@@ -37,7 +37,7 @@ module Tezos
         # Testing period has no proposal submission or voting, can skip block sync
         # Otherwise, if period already exists, see if blocks were already processed
         # in case process errored out before voting results were calculated
-        skip_block_sync = period_type == 'testing' ? true : @voting_period.all_blocks_synced
+        skip_block_sync = period_type == 'testing' || @voting_period.all_blocks_synced?
 
         if @voting_period.voting_power == nil
           url = Tezos::Rpc.new(@chain).url("blocks/#{block_hash}/votes/listings")

--- a/app/services/tezos/governance_sync_service.rb
+++ b/app/services/tezos/governance_sync_service.rb
@@ -35,7 +35,9 @@ module Tezos
         block_hash = block["hash"]
 
         # Testing period has no proposal submission or voting, can skip block sync
-        skip_block_sync = period_type == 'testing' ? true : false
+        # Otherwise, if period already exists, see if blocks were already processed
+        # in case process errored out before voting results were calculated
+        skip_block_sync = period_type == 'testing' ? true : @voting_period.all_blocks_synced
 
         if @voting_period.voting_power == nil
           url = Tezos::Rpc.new(@chain).url("blocks/#{block_hash}/votes/listings")


### PR DESCRIPTION
If governance_sync_service failed after blocks synced but before results calulated, it would have re-filled the blocks_to_sync array and started over.  This prevents it and will jump straight to the calulations method. 