### PR TITLE
add endorsers fallback to endorsed_block model

### DIFF
--- a/app/models/tezos/endorsed_block.rb
+++ b/app/models/tezos/endorsed_block.rb
@@ -43,4 +43,15 @@ class Tezos::EndorsedBlock < ActiveRecord::Base
   def missed?
     stolen?
   end
+
+  def endorsers
+    return self[:endorsers] if self[:endorsers].present?
+
+    sync = Tezos::EndorsersSyncService.new(chain, height)
+    sync.on_success do |endorsers|
+      update(endorsers: endorsers)
+    end
+    sync.request.run
+    return endorsers
+  end
 end


### PR DESCRIPTION
[Notion Task](https://www.notion.so/figmentnetworks/Endorsers-Fallback-2-c0a890802d9f44f8be6a7e69aaa26361)

I originally added this to the `Block` model, but the place that is causing the sync to fail is actually calling endorsers on the `EndorsedBlock` model. I still have a task on the board to backfill test coverage for this, but the sync is still stalling periodically so we should get this deployed asap.