### PR TITLE
add missing chain association to EndorsedBlock

### DIFF
--- a/app/models/tezos/endorsed_block.rb
+++ b/app/models/tezos/endorsed_block.rb
@@ -3,6 +3,7 @@ class Tezos::EndorsedBlock < ActiveRecord::Base
 
   belongs_to :cycle
   belongs_to :baker
+  has_one :chain, through: :cycle
   has_many :missed_bakes, foreign_key: :block_id
   has_many :double_bakes, foreign_key: :block_id
   has_many :double_endorsements, foreign_key: :block_id


### PR DESCRIPTION
[Notion Task](https://www.notion.so/figmentnetworks/Fix-stalled-Tezos-indexer-d3df6718151b47eeae26843fe3e4a9f8)

The `EndorsedBlock` model was missing an association to `chain` which was causing the sync task to error out. This should get it rolling again.