### PR TITLE
Endorsers fallback test

### DIFF
--- a/app/models/tezos/block.rb
+++ b/app/models/tezos/block.rb
@@ -41,7 +41,7 @@ class Tezos::Block < ApplicationRecord
     sync.on_success do |endorsers|
       update(endorsers: endorsers)
     end
-    sync.request.run
+    sync.run
     return endorsers
   end
 end

--- a/app/services/tezos/endorsers_sync_service.rb
+++ b/app/services/tezos/endorsers_sync_service.rb
@@ -28,6 +28,10 @@ module Tezos
       @request ||= Typhoeus::Request.new(url, method: :get)
     end
 
+    def run
+      request.run
+    end
+
     private
 
     def url

--- a/spec/factories/tezos/block_factories.rb
+++ b/spec/factories/tezos/block_factories.rb
@@ -1,0 +1,9 @@
+FactoryBot.define do
+  factory :tezos_block, class: "Tezos::Block" do
+    chain factory: :tezos_chain
+    baker factory: :tezos_baker
+    baker_priority { 1 }
+    endorsed_slots { 4294967295 }
+    timestamp { 2.minutes.ago }
+  end
+end

--- a/spec/models/tezos/block_spec.rb
+++ b/spec/models/tezos/block_spec.rb
@@ -1,0 +1,23 @@
+require "rails_helper"
+
+RSpec.describe Tezos::Block do 
+  describe "#endorsers" do
+    it "returns the value from the databse if present" do
+      endorsers_array = ["asdf123"]
+      block = create(:tezos_block, endorsers: endorsers_array )
+      
+      expect(block.endorsers).to eq endorsers_array
+    end
+
+    it "falls back to calling endorsers sync service" do
+      block = create(:tezos_block, endorsers: nil )
+
+      endorsers_array = ["asdf123", "testing123"]
+      callback = -> { block.update(endorsers: endorsers_array) }
+      allow_any_instance_of(Tezos::EndorsersSyncService).to receive(:run).and_return(endorsers_array)
+      allow_any_instance_of(Tezos::EndorsersSyncService).to receive(:on_success).and_return(callback)
+      
+      expect(block.endorsers).to eq endorsers_array
+    end
+  end
+end

--- a/spec/models/tezos/block_spec.rb
+++ b/spec/models/tezos/block_spec.rb
@@ -12,10 +12,19 @@ RSpec.describe Tezos::Block do
     it "falls back to calling endorsers sync service" do
       block = create(:tezos_block, endorsers: nil )
 
-      endorsers_array = ["asdf123", "testing123"]
-      callback = -> { block.update(endorsers: endorsers_array) }
-      allow_any_instance_of(Tezos::EndorsersSyncService).to receive(:run).and_return(endorsers_array)
-      allow_any_instance_of(Tezos::EndorsersSyncService).to receive(:on_success).and_return(callback)
+      sync = Tezos::EndorsersSyncService.new(block.chain, block.height)
+      url = sync.send(:url)
+
+      json = [
+        {
+          slots: [ 0, 1, 2, 3 ],
+          delegate: "test123"
+        }
+      ].to_json
+      endorsers_array = ["test123", "test123", "test123", "test123"]
+
+      response = Typhoeus::Response.new(code: 200, body: json)
+      Typhoeus.stub(url).and_return(response)
       
       expect(block.endorsers).to eq endorsers_array
     end


### PR DESCRIPTION
Adds test coverage for the `endorsers` method in `Tezos::Block` which pulls from the database but falls back to calling the RPC if the data is missing