### PR TITLE
fix active_bakers undefined variable

### DIFF
--- a/app/services/tezos/baker_sync_service.rb
+++ b/app/services/tezos/baker_sync_service.rb
@@ -14,6 +14,10 @@ module Tezos
         res = Typhoeus.get(url)
         all_bakers = JSON.parse(res.body)
 
+        url = Tezos::Rpc.new(chain).url("blocks/head/context/delegates", "active=true")
+        res = Typhoeus.get(url)
+        active_bakers = JSON.parse(res.body)
+
         found_bakers = Tezos::Baker.pluck(:id)
         missing_bakers = all_bakers - found_bakers
 


### PR DESCRIPTION
[Notion Task](https://www.notion.so/figmentnetworks/b47c0f8b935741d8ac28717ddeea2038?v=5e4e1d3854094b788ae2b612329f27e8&p=2e662a8fb48e4d7eb22eb4fbc2bf8209)

**Summary**
Adds a call to get active bakers in the baker sync service so we can set the active flag when saving new bakers to the database