### PR TITLE
update deprecated RPC fields

### DIFF
--- a/app/models/tezos/proposal.rb
+++ b/app/models/tezos/proposal.rb
@@ -8,7 +8,7 @@ class Tezos::Proposal < ApplicationRecord
     end
 
     data = Tezos::Rpc.new(self.chain).get("blocks/head/metadata")
-    current_period = data["level"]["voting_period"]
+    current_period = data["voting_period_info"]["voting_period"]["index"]
     elapsed_periods = current_period - self.start_period
 
     if elapsed_periods >= 4

--- a/app/services/tezos/governance_sync_service.rb
+++ b/app/services/tezos/governance_sync_service.rb
@@ -30,7 +30,7 @@ module Tezos
 
         url = Tezos::Rpc.new(@chain).url("blocks/#{@starting_block}")
         block = JSON.parse(Typhoeus.get(url).body)
-        period_type = block["metadata"]["voting_period_kind"]
+        period_type = block["metadata"]["voting_period_info"]["voting_period"]["kind"]
         starting_time = block["header"]["timestamp"]
         block_hash = block["hash"]
 

--- a/lib/tasks/sync.rake
+++ b/lib/tasks/sync.rake
@@ -22,8 +22,8 @@ task sync: :environment do
     # SYNC CYCLES
     # TODO: Save current cycle and latest block to Cycle
     data = Tezos::Rpc.new(chain).get("blocks/head/metadata")
-    current_cycle = data["level"]["cycle"]
-    latest_block  = data["level"]["level"]
+    current_cycle = data["level_info"]["cycle"]
+    latest_block  = data["level_info"]["level"]
 
     puts "#{chain.name} is currently on Cycle #{current_cycle} at Block #{latest_block}"
 

--- a/lib/tasks/sync_governance.rake
+++ b/lib/tasks/sync_governance.rake
@@ -13,8 +13,8 @@ task sync_governance: :environment do
     chains.each do |chain|
       # SYNC PROPOSALS
       data = Tezos::Rpc.new(chain).get("blocks/head/metadata")
-      current_period = data["level"]["voting_period"]
-      latest_block  = data["level"]["level"]
+      current_period = data["voting_period_info"]["voting_period"]["index"]
+      latest_block  = data["level_info"]["level"]
 
       Rails.logger.debug "#{chain.name} is currently on Period #{current_period} at Block #{latest_block}"
 


### PR DESCRIPTION
[Notion Task](https://www.notion.so/figmentnetworks/Handle-Edo-Protocol-23b7bd3a89524745977eb52b0ee894eb)

Updates the Tezos indexer to stop relying on deprecated RPC fields