### PR TITLE
handle nil period_start_time

### DIFF
--- a/app/models/tezos/voting_period.rb
+++ b/app/models/tezos/voting_period.rb
@@ -20,6 +20,7 @@ class Tezos::VotingPeriod < ApplicationRecord
   alias supermajority_reached supermajority_reached?
 
   def end_time_approximation
+    return nil if period_start_time.nil?
     self.period_start_time + 22.days + 18.hours
   end
 end

--- a/app/models/tezos/voting_period.rb
+++ b/app/models/tezos/voting_period.rb
@@ -2,6 +2,8 @@ class Tezos::VotingPeriod < ApplicationRecord
   belongs_to :chain
   has_many :ballots
 
+  validates :period_start_time, :period_type, presence: true
+
   def quorum_reached?
     rolls_voted = self.ballots.sum(&:rolls)
     return false if self.quorum.blank?


### PR DESCRIPTION
@avanderbeek @pawelnguyen It looks like the reason Governance is failing on Hubble is because the indexer is returning an error when requesting the voting periods. The last one in the database has a nil value for `period_start_time` and `period_type` - we'll probably need to set those values to get it working again, but I'm not sure why they are nil in the first place. @avanderbeek think you could look into it?