### PR TITLE
need data for block after voting period starting position

### DIFF
--- a/app/services/tezos/governance_sync_service.rb
+++ b/app/services/tezos/governance_sync_service.rb
@@ -223,7 +223,7 @@ module Tezos
 
     def start_block_data
       @start_block_data ||= begin
-        url = Tezos::Rpc.new(@chain).url("blocks/#{@starting_block}")
+        url = Tezos::Rpc.new(@chain).url("blocks/#{@starting_block + 1}")
         block = JSON.parse(Typhoeus.get(url).body, max_nesting: false)
       end
     end


### PR DESCRIPTION
@avanderbeek Looks like the change I made was a tiny bit off and caused the latest governance info to get messed up. I think with this fix it should work. The easiest approach would probably be to just delete the last Voting Period, its Ballots and the last 2 Proposals and let the sync re-import that data (hopefully correctly this time)