### PR TITLE
Governance Sync Fixes

### DIFF
--- a/app/services/tezos/block_data.rb
+++ b/app/services/tezos/block_data.rb
@@ -1,0 +1,72 @@
+module Tezos
+  class BlockData
+    attr_accessor :metadata, :hash, :timestamp
+
+    def initialize(data)
+      self.metadata = data["metadata"]
+      self.hash = data["hash"]
+      self.timestamp = data["header"]["timestamp"]
+    end
+
+    def self.retrieve(chain: Chain.primary, block_id: "head")
+      data = Rpc.new(chain).get("blocks/#{block_id}")
+      new(data)
+    end
+
+    def protocol
+      metadata["protocol"]
+    end
+
+    def next_protocol
+      metadata["next_protocol"]
+    end
+
+    def level
+      if metadata["level_info"]
+        metadata["level_info"]["level"]
+      else
+        metadata["level"]["level"]
+      end
+    end
+
+    def cycle
+      if metadata["level_info"]
+        metadata["level_info"]["cycle"]
+      else
+        metadata["level"]["cycle"]
+      end
+    end
+
+    def voting_period
+      if metadata["voting_period_info"]
+        metadata["voting_period_info"]["voting_period"]["index"]
+      else
+        metadata["level"]["voting_period"]
+      end
+    end
+
+    def voting_period_position
+      if metadata["voting_period_info"]
+        metadata["voting_period_info"]["position"]
+      else
+        metadata["level"]["voting_period_position"]
+      end
+    end
+
+    def voting_period_start_block
+      if metadata["voting_period_info"]
+        metadata["voting_period_info"]["voting_period"]["start_position"] + 1
+      else
+        level - voting_period_position
+      end
+    end
+
+    def voting_period_kind
+      if metadata["voting_period_info"]
+        metadata["voting_period_info"]["voting_period"]["kind"]
+      else
+        metadata["voting_period_kind"]
+      end
+    end
+  end
+end

--- a/lib/tasks/sync_governance.rake
+++ b/lib/tasks/sync_governance.rake
@@ -10,6 +10,19 @@ task sync_governance: :environment do
       next
     end
 
+
+    # TODO: GET START AND END USING THIS DATA
+    # data = Tezos::Rpc.new(chain).get("blocks/head/metadata")
+    # current_period = data["voting_period_info"]["voting_period"]["index"]
+                  # OR data["level"]["voting_period"]
+    # start_block    = data["voting_period"]["start_positon"] + 1
+                  # OR data["level"]["level"] - data["level"]["voting_period_position"]
+
+    # constants = Tezos::Rpc.new(chain).get("blocks/#{start_block}/context/constants")
+    # blocks_per_voting_period = constants["blocks_per_voting_period"]
+    # end_block = start_block + blocks_per_voting_period
+
+
     chains.each do |chain|
       # Get current period and start block from RPC; calculate end_block
       # TODO: Handle protocols before Edo

--- a/lib/tasks/sync_governance.rake
+++ b/lib/tasks/sync_governance.rake
@@ -23,10 +23,11 @@ task sync_governance: :environment do
         pd = Tezos::VotingPeriod.find_by(id: period)
         block_data     = Tezos::BlockData.retrieve(block_id: start_block, chain: chain)
         start_block    = block_data.voting_period_start_block
-        constants      = rpc.get("blocks/#{start_block}/context/constants")
-        end_block      = start_block + constants["blocks_per_voting_period"]
+        end_block      = block_data.voting_period_end_block
 
-        if pd.nil? || !pd.voting_processed || pd.start_position.nil? || pd.end_position.nil?
+        puts "SYNC PERIOD #{period} (start #{start_block} to end #{end_block})"
+
+        if period > 39 && (pd.nil? || !pd.voting_processed || pd.start_position.nil? || pd.end_position.nil?)
           Tezos::GovernanceSyncService.new(chain, period, start_block, end_block, latest_block, block_data).run
         end
 

--- a/lib/tasks/sync_governance.rake
+++ b/lib/tasks/sync_governance.rake
@@ -25,8 +25,6 @@ task sync_governance: :environment do
         start_block    = block_data.voting_period_start_block
         end_block      = block_data.voting_period_end_block
 
-        puts "SYNC PERIOD #{period} (start #{start_block} to end #{end_block})"
-
         if pd.nil? || !pd.voting_processed || pd.start_position.nil? || pd.end_position.nil?
           Tezos::GovernanceSyncService.new(chain, period, start_block, end_block, latest_block, block_data).run
         end

--- a/lib/tasks/sync_governance.rake
+++ b/lib/tasks/sync_governance.rake
@@ -27,7 +27,7 @@ task sync_governance: :environment do
 
         puts "SYNC PERIOD #{period} (start #{start_block} to end #{end_block})"
 
-        if period > 39 && (pd.nil? || !pd.voting_processed || pd.start_position.nil? || pd.end_position.nil?)
+        if pd.nil? || !pd.voting_processed || pd.start_position.nil? || pd.end_position.nil?
           Tezos::GovernanceSyncService.new(chain, period, start_block, end_block, latest_block, block_data).run
         end
 

--- a/lib/tasks/sync_governance.rake
+++ b/lib/tasks/sync_governance.rake
@@ -10,41 +10,28 @@ task sync_governance: :environment do
       next
     end
 
-
-    # TODO: GET START AND END USING THIS DATA
-    # data = Tezos::Rpc.new(chain).get("blocks/head/metadata")
-    # current_period = data["voting_period_info"]["voting_period"]["index"]
-                  # OR data["level"]["voting_period"]
-    # start_block    = data["voting_period"]["start_positon"] + 1
-                  # OR data["level"]["level"] - data["level"]["voting_period_position"]
-
-    # constants = Tezos::Rpc.new(chain).get("blocks/#{start_block}/context/constants")
-    # blocks_per_voting_period = constants["blocks_per_voting_period"]
-    # end_block = start_block + blocks_per_voting_period
-
-
     chains.each do |chain|
-      # Get current period and start block from RPC; calculate end_block
-      # TODO: Handle protocols before Edo
-      data = Tezos::Rpc.new(chain).get("blocks/head/metadata")
-      latest_block   = data["level_info"]["level"]
-      current_period = data["voting_period_info"]["voting_period"]["index"]
-      start_block    = data["voting_period_info"]["voting_period"]["start_position"]
-      end_block      = start_block + data["voting_period_info"]["position"] + data["voting_period_info"]["remaining"]
+      rpc            = Tezos::Rpc.new(chain)
+      start_block    = 2
+      meta           = rpc.get("blocks/head/metadata")
+      latest_block   = meta["level_info"].present? ? meta["level_info"]["level"] : meta["level"]["level"]
+      current_period = meta["voting_period_info"].present? ? meta["voting_period_info"]["voting_period"]["index"] : meta["level"]["voting_period"]
       Rails.logger.debug "#{chain.name} is currently on Period #{current_period} at Block #{latest_block}"
 
-      current_period.downto(0).each do |period|
-        # Find record in db
+      # Cycle through voting periods and sync those that are a) missing, b) incomplete, or c) don't have start / end positions
+      0.upto(current_period).each do |period|
         pd = Tezos::VotingPeriod.find_by(id: period)
+
         if pd.nil? || !pd.voting_processed || pd.start_position.nil? || pd.end_position.nil?
+          meta           = rpc.get("blocks/#{start_block}/metadata")
+          start_block    = meta["voting_period_info"].present? ? meta["voting_period_info"]["voting_period"]["start_position"] + 1 : meta["level"]["level"] - meta["level"]["voting_period_position"]
+          constants      = rpc.get("blocks/#{start_block}/context/constants")
+          end_block      = start_block + constants["blocks_per_voting_period"]
+
           Tezos::GovernanceSyncService.new(chain, period, start_block, end_block, latest_block).run
         end
 
-        # Get previous period start_block from RPC. we know current period start_block - 1 equals previous period end block.
-        end_block = start_block - 1
-        puts "Look up data for period #{period} with end block #{end_block}"
-        data = Tezos::Rpc.new(chain).get("blocks/#{end_block}/metadata")
-        start_block = data["voting_period_info"]["voting_period"]["start_position"]
+        start_block = end_block + 1
       end
     end
   end

--- a/lib/tasks/sync_governance.rake
+++ b/lib/tasks/sync_governance.rake
@@ -13,9 +13,9 @@ task sync_governance: :environment do
     chains.each do |chain|
       rpc            = Tezos::Rpc.new(chain)
       start_block    = 2
-      meta           = rpc.get("blocks/head/metadata")
-      latest_block   = meta["level_info"].present? ? meta["level_info"]["level"] : meta["level"]["level"]
-      current_period = meta["voting_period_info"].present? ? meta["voting_period_info"]["voting_period"]["index"] : meta["level"]["voting_period"]
+      block_data     = Tezos::BlockData.retrieve(block_id: 'head', chain: chain)
+      latest_block   = block_data.level
+      current_period = block_data.voting_period
       Rails.logger.debug "#{chain.name} is currently on Period #{current_period} at Block #{latest_block}"
 
       # Cycle through voting periods and sync those that are a) missing, b) incomplete, or c) don't have start / end positions
@@ -23,12 +23,12 @@ task sync_governance: :environment do
         pd = Tezos::VotingPeriod.find_by(id: period)
 
         if pd.nil? || !pd.voting_processed || pd.start_position.nil? || pd.end_position.nil?
-          meta           = rpc.get("blocks/#{start_block}/metadata")
-          start_block    = meta["voting_period_info"].present? ? meta["voting_period_info"]["voting_period"]["start_position"] + 1 : meta["level"]["level"] - meta["level"]["voting_period_position"]
+          block_data     = Tezos::BlockData.retrieve(block_id: start_block, chain: chain)
+          start_block    = block_data.voting_period_start_block
           constants      = rpc.get("blocks/#{start_block}/context/constants")
           end_block      = start_block + constants["blocks_per_voting_period"]
 
-          Tezos::GovernanceSyncService.new(chain, period, start_block, end_block, latest_block).run
+          Tezos::GovernanceSyncService.new(chain, period, start_block, end_block, latest_block, block_data).run
         end
 
         start_block = end_block + 1


### PR DESCRIPTION
@avanderbeek just tagging you so you can see what I'm doing. The data from the Tezos RPC is really confusing because they have `level` and `level_position` which are off by 1, and the constant for `blocks_per_voting_period` changed in Edo. That's partially what's causing the issues that I'm trying to fix. Also, I changed the code to iterate backwards, but that does not work with the way proposals are detected because it seems like it associates them with whatever period is being sync'd when it first finds a related ballot, so for example it currently shows the Florena proposal as being submitted in period 43 when it was really 41 or something like that. Anyway, just letting you know that I'm still working on this and think I found some better ways to get the correct start and end blocks for each period. Hopefully I'll have it working again in the next day or 2.