### PR TITLE
RPC updated operation type for endorsements

### DIFF
--- a/app/services/tezos/cycle_sync_service.rb
+++ b/app/services/tezos/cycle_sync_service.rb
@@ -66,7 +66,7 @@ module Tezos
                     res = Tezos::EndorsementResults.new(height: height, bitmask: 0, endorsers: [])
 
                     block_info["operations"].flatten.each do |op|
-                      endorsements = op["contents"].select { |subop| subop["kind"] == "endorsement" }
+                      endorsements = op["contents"].select { |subop| ["endorsement", "endorsement_with_slot"].include?(subop["kind"]) }
                       endorsements.each do |endorsement|
                         endorsement["metadata"]["slots"].each do |slot|
                           res.set_true(slot + 1) # slots are 1-indexed in EndorsementResults and 0-indexed in RPC result


### PR DESCRIPTION
[Notion Task](https://www.notion.so/figmentnetworks/Investigate-impact-of-Florence-Protocol-0ec0b97cd4414418b4a2c40adb3191a5)

**Summary**
In the Florence protocol, the RPC was changed and caused our event detection for missed endorsements to break. This updates the indexer to look for operations with kind of "endorsement" or "endorsement_with_slot" in order to handle older protocols along with the current one. 

I tested locally and prior to this change, the code detected that all slots were missed for the latest block. After the update, it did not show any missed slots.